### PR TITLE
Feature/infraregistry 292 design and test generic varuste type

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This database is a fork of [Gispo's database](https://github.com/GispoCoding/inf
 
 ## Prerequisites
 Ensure you have the following installed:
-- .NET 8 SDK
+- .NET 10 SDK
 - PostgreSQL database + PostGIS extension
 
 ## How to use

--- a/Scripts/059_create_equipment.sql
+++ b/Scripts/059_create_equipment.sql
@@ -121,7 +121,7 @@ ALTER TABLE kohteet.equipment_plan_link OWNER TO $DatabaseOwner$;
 -- Junction table: equipment <-> varustetoimenpide (maintenance actions)
 CREATE TABLE kohteet.equipment_maintenance_action (
     equipment_id          INTEGER NOT NULL REFERENCES kohteet.equipment(id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED,
-    maintenance_action_id INTEGER NOT NULL REFERENCES kohteet.varustetoimenpide(id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    maintenance_action_id INTEGER NOT NULL REFERENCES kohteet.varuste_toimenpide(id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED,
     CONSTRAINT equipment_maintenance_action_pk PRIMARY KEY (equipment_id, maintenance_action_id)
 );
 ALTER TABLE kohteet.equipment_maintenance_action OWNER TO $DatabaseOwner$;

--- a/Scripts/059_create_equipment.sql
+++ b/Scripts/059_create_equipment.sql
@@ -1,0 +1,127 @@
+-- ============================================================================
+-- 059_create_equipment.sql
+-- Creates the generic equipment model: equipment_type code list, equipment
+-- table with JSONB properties, indexes, and junction tables.
+-- ============================================================================
+
+-- Equipment type code list table (koodisto pattern: id, name, sort_order)
+CREATE TABLE kohteet.equipment_type (
+    id          integer PRIMARY KEY,
+    name        text NOT NULL,
+    sort_order  integer
+);
+ALTER TABLE kohteet.equipment_type OWNER TO $DatabaseOwner$;
+
+-- Seed with legacy Phase 1 types and planned Phase 2+ types
+INSERT INTO kohteet.equipment_type (id, name, sort_order) VALUES (1, 'hulevesi', 1);
+INSERT INTO kohteet.equipment_type (id, name, sort_order) VALUES (2, 'jate', 2);
+INSERT INTO kohteet.equipment_type (id, name, sort_order) VALUES (3, 'valaisin', 3);
+INSERT INTO kohteet.equipment_type (id, name, sort_order) VALUES (4, 'liikennemerkki', 4);
+INSERT INTO kohteet.equipment_type (id, name, sort_order) VALUES (5, 'kaapeli', 5);
+INSERT INTO kohteet.equipment_type (id, name, sort_order) VALUES (6, 'ryhmasulake', 6);
+INSERT INTO kohteet.equipment_type (id, name, sort_order) VALUES (7, 'kaluste', 7);
+INSERT INTO kohteet.equipment_type (id, name, sort_order) VALUES (8, 'opaste', 8);
+INSERT INTO kohteet.equipment_type (id, name, sort_order) VALUES (9, 'ymparistotaide', 9);
+INSERT INTO kohteet.equipment_type (id, name, sort_order) VALUES (10, 'melu', 10);
+INSERT INTO kohteet.equipment_type (id, name, sort_order) VALUES (11, 'leikkivaline', 11);
+INSERT INTO kohteet.equipment_type (id, name, sort_order) VALUES (12, 'liikunta', 12);
+INSERT INTO kohteet.equipment_type (id, name, sort_order) VALUES (13, 'pysakointiruutu', 13);
+INSERT INTO kohteet.equipment_type (id, name, sort_order) VALUES (14, 'rakenne', 14);
+INSERT INTO kohteet.equipment_type (id, name, sort_order) VALUES (15, 'ajoratamerkinta', 15);
+INSERT INTO kohteet.equipment_type (id, name, sort_order) VALUES (16, 'muuvaruste', 16);
+
+-- Generic equipment table
+CREATE TABLE kohteet.equipment (
+    id                      SERIAL PRIMARY KEY,
+    equipment_type_id       INTEGER NOT NULL REFERENCES kohteet.equipment_type(id),
+    properties              JSONB NOT NULL DEFAULT '{}',
+
+    -- Identity & metadata
+    uuid                    UUID NOT NULL DEFAULT uuid_generate_v4(),
+    metadata                TEXT,
+
+    -- Validity period
+    valid_from              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    valid_to                TIMESTAMPTZ,
+
+    -- Spatial data
+    geom_polygon            GEOMETRY(Polygon, $Srid$),
+    geom_point              GEOMETRY(Point, $Srid$),
+    geom_line               GEOMETRY(LineString, $Srid$),
+
+    -- Tenant
+    municipality_id         INTEGER NOT NULL DEFAULT $MunicipalityCode$,
+
+    -- Audit
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    modified_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by              VARCHAR(200) NOT NULL,
+    modified_by             VARCHAR(200) NOT NULL,
+
+    -- Soft delete
+    is_deleted              BOOLEAN NOT NULL DEFAULT FALSE,
+
+    -- Common equipment fields (columns, not in JSONB)
+    model                   VARCHAR(200),
+    manufacturer            VARCHAR(200),
+    manufacture_year        SMALLINT,
+    renovation_year         SMALLINT,
+    direction               DOUBLE PRECISION,
+    owner                   VARCHAR(200),
+    holder                  VARCHAR(200),
+    maintainer              VARCHAR(200),
+    additional_info         TEXT,
+    surveyor                VARCHAR(200),
+    material_id             INTEGER REFERENCES kohteet.varustemateriaali(id),
+    creation_method_id      INTEGER REFERENCES kohteet.luontitapatyyppi(id),
+    location_uncertainty_id INTEGER REFERENCES kohteet.sijaintiepavarmuustyyppi(id),
+    lifecycle_id            INTEGER REFERENCES kohteet.koodisto_varuste_elinkaari(id),
+    status_id               INTEGER REFERENCES kohteet.koodisto_varuste_tila(id),
+    condition_id            INTEGER REFERENCES kohteet.koodisto_varuste_kunto(id),
+    address_id              INTEGER REFERENCES kohteet.osoite(id),
+    green_area_part_id      INTEGER REFERENCES kohteet.viheralueenosa(id),
+    street_area_part_id     INTEGER REFERENCES kohteet.katualueenosa(id)
+);
+ALTER TABLE kohteet.equipment OWNER TO $DatabaseOwner$;
+
+-- Indexes
+CREATE INDEX idx_equipment_type ON kohteet.equipment(equipment_type_id);
+CREATE INDEX idx_equipment_municipality ON kohteet.equipment(municipality_id);
+CREATE INDEX idx_equipment_uuid ON kohteet.equipment(uuid);
+CREATE INDEX idx_equipment_properties ON kohteet.equipment USING GIN (properties);
+CREATE INDEX idx_equipment_geom_point ON kohteet.equipment USING GIST (geom_point);
+CREATE INDEX idx_equipment_geom_polygon ON kohteet.equipment USING GIST (geom_polygon);
+CREATE INDEX idx_equipment_geom_line ON kohteet.equipment USING GIST (geom_line);
+CREATE INDEX idx_equipment_not_deleted ON kohteet.equipment(is_deleted) WHERE NOT is_deleted;
+
+-- Junction table: equipment <-> liite (attachments)
+CREATE TABLE kohteet.equipment_attachment (
+    equipment_id  INTEGER NOT NULL REFERENCES kohteet.equipment(id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    attachment_id INTEGER NOT NULL REFERENCES kohteet.liite(id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT equipment_attachment_pk PRIMARY KEY (equipment_id, attachment_id)
+);
+ALTER TABLE kohteet.equipment_attachment OWNER TO $DatabaseOwner$;
+
+-- Junction table: equipment <-> urakka (contracts)
+CREATE TABLE kohteet.equipment_contract (
+    equipment_id INTEGER NOT NULL REFERENCES kohteet.equipment(id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    contract_id  INTEGER NOT NULL REFERENCES kohteet.urakka(id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT equipment_contract_pk PRIMARY KEY (equipment_id, contract_id)
+);
+ALTER TABLE kohteet.equipment_contract OWNER TO $DatabaseOwner$;
+
+-- Junction table: equipment <-> suunnitelmalinkki (plan links)
+CREATE TABLE kohteet.equipment_plan_link (
+    equipment_id INTEGER NOT NULL REFERENCES kohteet.equipment(id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    plan_link_id INTEGER NOT NULL REFERENCES kohteet.suunnitelmalinkki(id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT equipment_plan_link_pk PRIMARY KEY (equipment_id, plan_link_id)
+);
+ALTER TABLE kohteet.equipment_plan_link OWNER TO $DatabaseOwner$;
+
+-- Junction table: equipment <-> varustetoimenpide (maintenance actions)
+CREATE TABLE kohteet.equipment_maintenance_action (
+    equipment_id          INTEGER NOT NULL REFERENCES kohteet.equipment(id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    maintenance_action_id INTEGER NOT NULL REFERENCES kohteet.varustetoimenpide(id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT equipment_maintenance_action_pk PRIMARY KEY (equipment_id, maintenance_action_id)
+);
+ALTER TABLE kohteet.equipment_maintenance_action OWNER TO $DatabaseOwner$;

--- a/Scripts/060_migrate_legacy_equipment.sql
+++ b/Scripts/060_migrate_legacy_equipment.sql
@@ -6,7 +6,7 @@
 -- Uses ON CONFLICT DO NOTHING for idempotency.
 -- ============================================================================
 
-DO $migrate_legacy$
+DO $$
 DECLARE
     v_migrated   integer;
     v_total      integer;
@@ -457,4 +457,4 @@ RAISE NOTICE '========================================';
 RAISE NOTICE 'Legacy equipment migration complete.';
 RAISE NOTICE '========================================';
 
-END $migrate_legacy$;
+END $$;

--- a/Scripts/060_migrate_legacy_equipment.sql
+++ b/Scripts/060_migrate_legacy_equipment.sql
@@ -1,0 +1,460 @@
+-- ============================================================================
+-- 060_migrate_legacy_equipment.sql
+-- Migrates legacy per-type equipment data into the generic kohteet.equipment
+-- table. For each legacy type, common columns are copied directly and
+-- type-specific columns are extracted into JSONB properties.
+-- Uses ON CONFLICT DO NOTHING for idempotency.
+-- ============================================================================
+
+DO $migrate_legacy$
+DECLARE
+    v_migrated   integer;
+    v_total      integer;
+    v_table_name text;
+BEGIN
+
+-- ============================================================================
+-- 1. HULEVESI (equipment_type_id = 1)
+-- ============================================================================
+v_table_name := 'hulevesi';
+
+SELECT count(*) INTO v_total FROM kohteet.hulevesi;
+
+INSERT INTO kohteet.equipment (
+    equipment_type_id, properties,
+    uuid, metadata, valid_from, valid_to,
+    geom_polygon, geom_point, geom_line,
+    municipality_id,
+    created_at, modified_at, created_by, modified_by,
+    is_deleted,
+    model, manufacturer, manufacture_year, renovation_year,
+    direction, owner, holder, maintainer, additional_info, surveyor,
+    material_id, creation_method_id, location_uncertainty_id,
+    lifecycle_id, status_id, condition_id,
+    address_id, green_area_part_id, street_area_part_id
+)
+SELECT
+    1,
+    jsonb_build_object(
+        'hulevesityyppiId', hulevesityyppi_id,
+        'kannenHalkaisija', kannen_halkaisija,
+        'kannenTyyppiId', kannen_tyyppi_id
+    ),
+    yksilointitieto::uuid, metatieto, alkuhetki, loppuhetki,
+    geom_poly, geom_piste, geom_line,
+    kunta_id,
+    luonti_pvm, muokkaus_pvm, datan_luoja, muokkaaja,
+    is_deleted,
+    malli, valmistaja, valmistumisvuosi, perusparannusvuosi,
+    suunta, omistaja, haltija, kunnossapitaja, lisatietoja, inventoija,
+    materiaali_id, luontitapa_id, sijaintiepavarmuus_id,
+    elinkaari_id, tila_id, kunto_id,
+    osoite_id, kuuluuviheralueenosaan, kuuluukatualueenosaan
+FROM kohteet.hulevesi
+ON CONFLICT DO NOTHING;
+
+GET DIAGNOSTICS v_migrated = ROW_COUNT;
+RAISE NOTICE 'hulevesi: migrated % of % records', v_migrated, v_total;
+
+-- Hulevesi junction tables
+INSERT INTO kohteet.equipment_attachment (equipment_id, attachment_id)
+SELECT e.id, hl.liite_id
+FROM kohteet.hulevesi_liite hl
+JOIN kohteet.hulevesi h ON h.id = hl.hulevesi_id
+JOIN kohteet.equipment e ON e.uuid = h.yksilointitieto::uuid AND e.equipment_type_id = 1
+ON CONFLICT DO NOTHING;
+
+INSERT INTO kohteet.equipment_contract (equipment_id, contract_id)
+SELECT e.id, hu.urakka_id
+FROM kohteet.hulevesi_urakka hu
+JOIN kohteet.hulevesi h ON h.id = hu.hulevesi_id
+JOIN kohteet.equipment e ON e.uuid = h.yksilointitieto::uuid AND e.equipment_type_id = 1
+ON CONFLICT DO NOTHING;
+
+INSERT INTO kohteet.equipment_plan_link (equipment_id, plan_link_id)
+SELECT e.id, hs.suunnitelmalinkki_id
+FROM kohteet.hulevesi_suunnitelmalinkki hs
+JOIN kohteet.hulevesi h ON h.id = hs.hulevesi_id
+JOIN kohteet.equipment e ON e.uuid = h.yksilointitieto::uuid AND e.equipment_type_id = 1
+ON CONFLICT DO NOTHING;
+
+INSERT INTO kohteet.equipment_maintenance_action (equipment_id, maintenance_action_id)
+SELECT e.id, hvt.varuste_toimenpide_id
+FROM kohteet.hulevesi_varuste_toimenpide_linkki hvt
+JOIN kohteet.hulevesi h ON h.id = hvt.hulevesi_id
+JOIN kohteet.equipment e ON e.uuid = h.yksilointitieto::uuid AND e.equipment_type_id = 1
+ON CONFLICT DO NOTHING;
+
+-- ============================================================================
+-- 2. JATE (equipment_type_id = 2)
+-- ============================================================================
+v_table_name := 'jate';
+SELECT count(*) INTO v_total FROM kohteet.jate;
+
+INSERT INTO kohteet.equipment (
+    equipment_type_id, properties,
+    uuid, metadata, valid_from, valid_to,
+    geom_polygon, geom_point, geom_line,
+    municipality_id,
+    created_at, modified_at, created_by, modified_by,
+    is_deleted,
+    model, manufacturer, manufacture_year, renovation_year,
+    direction, owner, holder, maintainer, additional_info, surveyor,
+    material_id, creation_method_id, location_uncertainty_id,
+    lifecycle_id, status_id, condition_id,
+    address_id, green_area_part_id, street_area_part_id
+)
+SELECT
+    2,
+    jsonb_build_object(
+        'jatetyyppiId', jatetyyppi_id,
+        'koko', koko,
+        'putkikeraysjarjestelmaKytkin', putkikeraysjarjestelma_kytkin,
+        'sijaintiMaanPinnallaKytkin', sijainti_maan_pinnalla_kytkin,
+        'vaarallistenJateastiaKytkin', vaarallisten_jateastia_kytkin,
+        'tyhjennysvaliViikkoinaKesa', tyhjennysvali_viikkoina_kesa,
+        'tyhjennysvaliViikkoinaTalvi', tyhjennysvali_viikkoina_talvi,
+        'tarkastusvaliId', tarkastusvali_id
+    ),
+    yksilointitieto::uuid, metatieto, alkuhetki, loppuhetki,
+    geom_poly, geom_piste, geom_line,
+    kunta_id,
+    luonti_pvm, muokkaus_pvm, datan_luoja, muokkaaja,
+    is_deleted,
+    malli, valmistaja, valmistumisvuosi, perusparannusvuosi,
+    suunta, omistaja, haltija, kunnossapitaja, lisatietoja, inventoija,
+    materiaali_id, luontitapa_id, sijaintiepavarmuus_id,
+    elinkaari_id, tila_id, kunto_id,
+    osoite_id, kuuluuviheralueenosaan, kuuluukatualueenosaan
+FROM kohteet.jate
+ON CONFLICT DO NOTHING;
+
+GET DIAGNOSTICS v_migrated = ROW_COUNT;
+RAISE NOTICE 'jate: migrated % of % records', v_migrated, v_total;
+
+-- Jate junction tables
+INSERT INTO kohteet.equipment_attachment (equipment_id, attachment_id)
+SELECT e.id, jl.liite_id
+FROM kohteet.jate_liite jl
+JOIN kohteet.jate j ON j.id = jl.jate_id
+JOIN kohteet.equipment e ON e.uuid = j.yksilointitieto::uuid AND e.equipment_type_id = 2
+ON CONFLICT DO NOTHING;
+
+INSERT INTO kohteet.equipment_contract (equipment_id, contract_id)
+SELECT e.id, ju.urakka_id
+FROM kohteet.jate_urakka ju
+JOIN kohteet.jate j ON j.id = ju.jate_id
+JOIN kohteet.equipment e ON e.uuid = j.yksilointitieto::uuid AND e.equipment_type_id = 2
+ON CONFLICT DO NOTHING;
+
+INSERT INTO kohteet.equipment_plan_link (equipment_id, plan_link_id)
+SELECT e.id, js.suunnitelmalinkki_id
+FROM kohteet.jate_suunnitelmalinkki js
+JOIN kohteet.jate j ON j.id = js.jate_id
+JOIN kohteet.equipment e ON e.uuid = j.yksilointitieto::uuid AND e.equipment_type_id = 2
+ON CONFLICT DO NOTHING;
+
+INSERT INTO kohteet.equipment_maintenance_action (equipment_id, maintenance_action_id)
+SELECT e.id, jvt.varuste_toimenpide_id
+FROM kohteet.jate_varuste_toimenpide_linkki jvt
+JOIN kohteet.jate j ON j.id = jvt.jate_id
+JOIN kohteet.equipment e ON e.uuid = j.yksilointitieto::uuid AND e.equipment_type_id = 2
+ON CONFLICT DO NOTHING;
+
+-- ============================================================================
+-- 3. VALAISIN (equipment_type_id = 3)
+-- ============================================================================
+v_table_name := 'valaisin';
+SELECT count(*) INTO v_total FROM kohteet.valaisin;
+
+INSERT INTO kohteet.equipment (
+    equipment_type_id, properties,
+    uuid, metadata, valid_from, valid_to,
+    geom_polygon, geom_point, geom_line,
+    municipality_id,
+    created_at, modified_at, created_by, modified_by,
+    is_deleted,
+    model, manufacturer, manufacture_year, renovation_year,
+    direction, owner, holder, maintainer, additional_info, surveyor,
+    material_id, creation_method_id, location_uncertainty_id,
+    lifecycle_id, status_id, condition_id,
+    address_id, green_area_part_id, street_area_part_id
+)
+SELECT
+    3,
+    jsonb_build_object(
+        'valaisinkeskusId', valaisinkeskus_id,
+        'valaisintyyppiId', valaisintyyppi_id,
+        'pylvastyyppiId', pylvastyyppi_id,
+        'polttimotyyppiId', polttimotyyppi_id,
+        'kaapelityyppiId', kaapelityyppi_id,
+        'pylvaskorkeus', pylvaskorkeus,
+        'asennuskorkeus', asennuskorkeus,
+        'valaisinvarrenPituus', valaisinvarren_pituus,
+        'pylvaanTuentaId', pylvaan_tuenta_id,
+        'varsityyppiId', varsityyppi_id,
+        'yhteiskayttopylvas', yhteiskayttopylvas,
+        'valaisinmaara', valaisinmaara,
+        'lamppujenMaara', lamppujen_maara,
+        'valaistusluokkaId', valaistusluokka_id,
+        'valaisinAsennustapaId', valaisin_asennustapa_id,
+        'valaisinTakuuperusteetId', valaisin_takuuperusteet_id,
+        'valaisinTakuunPaattymispvm', valaisin_takuun_paattymispvm,
+        'valaisinTakuunVastaaja', valaisin_takuun_vastaaja,
+        'pylvaanMaadoitus', pylvaan_maadoitus,
+        'maadoitusarvo', maadoitusarvo,
+        'pylvasValmistaja', pylvas_valmistaja,
+        'jalusta', jalusta,
+        'valaisinValmistaja', valaisin_valmistaja,
+        'valaisinMalli', valaisin_malli,
+        'valaisinTeho', valaisin_teho,
+        'valaisinOptiikka', valaisin_optiikka,
+        'himmennysprofiili', himmennysprofiili,
+        'lampunValmistaja', lampun_valmistaja,
+        'tarkenne', tarkenne
+    ),
+    yksilointitieto::uuid, metatieto, alkuhetki, loppuhetki,
+    geom_poly, geom_piste, geom_line,
+    kunta_id,
+    luonti_pvm, muokkaus_pvm, datan_luoja, muokkaaja,
+    is_deleted,
+    malli, valmistaja, valmistumisvuosi, perusparannusvuosi,
+    suunta, omistaja, haltija, kunnossapitaja, lisatietoja, inventoija,
+    materiaali_id, luontitapa_id, sijaintiepavarmuus_id,
+    elinkaari_id, tila_id, kunto_id,
+    osoite_id, kuuluuviheralueenosaan, kuuluukatualueenosaan
+FROM kohteet.valaisin
+ON CONFLICT DO NOTHING;
+
+GET DIAGNOSTICS v_migrated = ROW_COUNT;
+RAISE NOTICE 'valaisin: migrated % of % records', v_migrated, v_total;
+
+-- Valaisin junction tables
+INSERT INTO kohteet.equipment_attachment (equipment_id, attachment_id)
+SELECT e.id, vl.liite_id
+FROM kohteet.valaisin_liite vl
+JOIN kohteet.valaisin v ON v.id = vl.valaisin_id
+JOIN kohteet.equipment e ON e.uuid = v.yksilointitieto::uuid AND e.equipment_type_id = 3
+ON CONFLICT DO NOTHING;
+
+INSERT INTO kohteet.equipment_contract (equipment_id, contract_id)
+SELECT e.id, vu.urakka_id
+FROM kohteet.valaisin_urakka vu
+JOIN kohteet.valaisin v ON v.id = vu.valaisin_id
+JOIN kohteet.equipment e ON e.uuid = v.yksilointitieto::uuid AND e.equipment_type_id = 3
+ON CONFLICT DO NOTHING;
+
+INSERT INTO kohteet.equipment_plan_link (equipment_id, plan_link_id)
+SELECT e.id, vs.suunnitelmalinkki_id
+FROM kohteet.valaisin_suunnitelmalinkki vs
+JOIN kohteet.valaisin v ON v.id = vs.valaisin_id
+JOIN kohteet.equipment e ON e.uuid = v.yksilointitieto::uuid AND e.equipment_type_id = 3
+ON CONFLICT DO NOTHING;
+
+INSERT INTO kohteet.equipment_maintenance_action (equipment_id, maintenance_action_id)
+SELECT e.id, vvt.varuste_toimenpide_id
+FROM kohteet.valaisin_varuste_toimenpide_linkki vvt
+JOIN kohteet.valaisin v ON v.id = vvt.valaisin_id
+JOIN kohteet.equipment e ON e.uuid = v.yksilointitieto::uuid AND e.equipment_type_id = 3
+ON CONFLICT DO NOTHING;
+
+-- ============================================================================
+-- 4. LIIKENNEMERKKI (equipment_type_id = 4)
+-- ============================================================================
+v_table_name := 'liikennemerkki';
+SELECT count(*) INTO v_total FROM kohteet.liikennemerkki;
+
+INSERT INTO kohteet.equipment (
+    equipment_type_id, properties,
+    uuid, metadata, valid_from, valid_to,
+    geom_polygon, geom_point, geom_line,
+    municipality_id,
+    created_at, modified_at, created_by, modified_by,
+    is_deleted,
+    model, manufacturer, manufacture_year, renovation_year,
+    direction, owner, holder, maintainer, additional_info, surveyor,
+    material_id, creation_method_id, location_uncertainty_id,
+    lifecycle_id, status_id, condition_id,
+    address_id, green_area_part_id, street_area_part_id
+)
+SELECT
+    4,
+    jsonb_build_object(
+        'liikennemerkkityyppiId', liikennemerkkityyppi_id,
+        'liikennemerkkityyppi2020Id', liikennemerkkityyppi2020_id,
+        'teksti', teksti,
+        'arvo', arvo,
+        'rakenneId', rakenne_id,
+        'kokoId', koko_id,
+        'korkeus', korkeus,
+        'kalvonTyyppiId', kalvon_tyyppi_id,
+        'sijaintitarkenneId', sijaintitarkenne_id,
+        'kaistanTyyppiId', kaistan_tyyppi_id,
+        'kaistanNumeroId', kaistan_numero_id,
+        'kaksipuoleinenKytkin', kaksipuoleinen_kytkin,
+        'suuntima', suuntima,
+        'lisakilvenVariId', lisakilven_vari_id
+    ),
+    yksilointitieto::uuid, metatieto, alkuhetki, loppuhetki,
+    geom_poly, geom_piste, geom_line,
+    kunta_id,
+    luonti_pvm, muokkaus_pvm, datan_luoja, muokkaaja,
+    is_deleted,
+    malli, valmistaja, valmistumisvuosi, perusparannusvuosi,
+    suunta, omistaja, haltija, kunnossapitaja, lisatietoja, inventoija,
+    materiaali_id, luontitapa_id, sijaintiepavarmuus_id,
+    elinkaari_id, tila_id, kunto_id,
+    osoite_id, kuuluuviheralueenosaan, kuuluukatualueenosaan
+FROM kohteet.liikennemerkki
+ON CONFLICT DO NOTHING;
+
+GET DIAGNOSTICS v_migrated = ROW_COUNT;
+RAISE NOTICE 'liikennemerkki: migrated % of % records', v_migrated, v_total;
+
+-- Liikennemerkki junction tables
+INSERT INTO kohteet.equipment_attachment (equipment_id, attachment_id)
+SELECT e.id, ll.liite_id
+FROM kohteet.liikennemerkki_liite ll
+JOIN kohteet.liikennemerkki lm ON lm.id = ll.liikennemerkki_id
+JOIN kohteet.equipment e ON e.uuid = lm.yksilointitieto::uuid AND e.equipment_type_id = 4
+ON CONFLICT DO NOTHING;
+
+INSERT INTO kohteet.equipment_contract (equipment_id, contract_id)
+SELECT e.id, lu.urakka_id
+FROM kohteet.liikennemerkki_urakka lu
+JOIN kohteet.liikennemerkki lm ON lm.id = lu.liikennemerkki_id
+JOIN kohteet.equipment e ON e.uuid = lm.yksilointitieto::uuid AND e.equipment_type_id = 4
+ON CONFLICT DO NOTHING;
+
+INSERT INTO kohteet.equipment_plan_link (equipment_id, plan_link_id)
+SELECT e.id, ls.suunnitelmalinkki_id
+FROM kohteet.liikennemerkki_suunnitelmalinkki ls
+JOIN kohteet.liikennemerkki lm ON lm.id = ls.liikennemerkki_id
+JOIN kohteet.equipment e ON e.uuid = lm.yksilointitieto::uuid AND e.equipment_type_id = 4
+ON CONFLICT DO NOTHING;
+
+INSERT INTO kohteet.equipment_maintenance_action (equipment_id, maintenance_action_id)
+SELECT e.id, lvt.varuste_toimenpide_id
+FROM kohteet.liikennemerkki_varuste_toimenpide_linkki lvt
+JOIN kohteet.liikennemerkki lm ON lm.id = lvt.liikennemerkki_id
+JOIN kohteet.equipment e ON e.uuid = lm.yksilointitieto::uuid AND e.equipment_type_id = 4
+ON CONFLICT DO NOTHING;
+
+-- ============================================================================
+-- 5. KAAPELI (equipment_type_id = 5)
+-- ============================================================================
+v_table_name := 'kaapeli';
+SELECT count(*) INTO v_total FROM kohteet.kaapeli;
+
+INSERT INTO kohteet.equipment (
+    equipment_type_id, properties,
+    uuid, metadata, valid_from, valid_to,
+    geom_polygon, geom_point, geom_line,
+    municipality_id,
+    created_at, modified_at, created_by, modified_by,
+    is_deleted,
+    model, manufacturer, manufacture_year, renovation_year,
+    direction, owner, holder, maintainer, additional_info, surveyor,
+    material_id, creation_method_id, location_uncertainty_id,
+    lifecycle_id, status_id, condition_id,
+    address_id, green_area_part_id, street_area_part_id
+)
+SELECT
+    5,
+    jsonb_build_object(
+        'valaisinkeskusId', valaisinkeskus_id,
+        'kaapelinTarkoitusId', kaapelin_tarkoitus_id,
+        'kaapelityyppiId', kaapelityyppi_id
+    ),
+    yksilointitieto::uuid, metatieto, alkuhetki, loppuhetki,
+    geom_poly, geom_piste, geom_line,
+    kunta_id,
+    luonti_pvm, muokkaus_pvm, datan_luoja, muokkaaja,
+    is_deleted,
+    malli, valmistaja, valmistumisvuosi, perusparannusvuosi,
+    suunta, omistaja, haltija, kunnossapitaja, lisatietoja, inventoija,
+    materiaali_id, luontitapa_id, sijaintiepavarmuus_id,
+    elinkaari_id, tila_id, kunto_id,
+    osoite_id, kuuluuviheralueenosaan, kuuluukatualueenosaan
+FROM kohteet.kaapeli
+ON CONFLICT DO NOTHING;
+
+GET DIAGNOSTICS v_migrated = ROW_COUNT;
+RAISE NOTICE 'kaapeli: migrated % of % records', v_migrated, v_total;
+
+-- Kaapeli junction tables
+INSERT INTO kohteet.equipment_attachment (equipment_id, attachment_id)
+SELECT e.id, kl.liite_id
+FROM kohteet.kaapeli_liite kl
+JOIN kohteet.kaapeli k ON k.id = kl.kaapeli_id
+JOIN kohteet.equipment e ON e.uuid = k.yksilointitieto::uuid AND e.equipment_type_id = 5
+ON CONFLICT DO NOTHING;
+
+INSERT INTO kohteet.equipment_contract (equipment_id, contract_id)
+SELECT e.id, ku.urakka_id
+FROM kohteet.kaapeli_urakka ku
+JOIN kohteet.kaapeli k ON k.id = ku.kaapeli_id
+JOIN kohteet.equipment e ON e.uuid = k.yksilointitieto::uuid AND e.equipment_type_id = 5
+ON CONFLICT DO NOTHING;
+
+INSERT INTO kohteet.equipment_plan_link (equipment_id, plan_link_id)
+SELECT e.id, ks.suunnitelmalinkki_id
+FROM kohteet.kaapeli_suunnitelmalinkki ks
+JOIN kohteet.kaapeli k ON k.id = ks.kaapeli_id
+JOIN kohteet.equipment e ON e.uuid = k.yksilointitieto::uuid AND e.equipment_type_id = 5
+ON CONFLICT DO NOTHING;
+
+INSERT INTO kohteet.equipment_maintenance_action (equipment_id, maintenance_action_id)
+SELECT e.id, kvt.varuste_toimenpide_id
+FROM kohteet.kaapeli_varuste_toimenpide_linkki kvt
+JOIN kohteet.kaapeli k ON k.id = kvt.kaapeli_id
+JOIN kohteet.equipment e ON e.uuid = k.yksilointitieto::uuid AND e.equipment_type_id = 5
+ON CONFLICT DO NOTHING;
+
+-- ============================================================================
+-- 6. RYHMASULAKE (equipment_type_id = 6)
+-- Note: ryhmasulake inherits from abstractinfraomaisuuskohde, NOT
+-- abstractvaruste. It has no geometry, material, or standard varuste
+-- common columns. Only metadata/audit columns and type-specific fields.
+-- ============================================================================
+v_table_name := 'ryhmasulake';
+SELECT count(*) INTO v_total FROM kohteet.ryhmasulake;
+
+INSERT INTO kohteet.equipment (
+    equipment_type_id, properties,
+    uuid, metadata, valid_from, valid_to,
+    municipality_id,
+    created_at, modified_at, created_by, modified_by,
+    is_deleted
+)
+SELECT
+    6,
+    jsonb_build_object(
+        'valaisinkeskusId', valaisinkeskus_id,
+        'tyyppiId', tyyppi_id,
+        'laukaisukayraId', laukaisukayra_id,
+        'virtaArvoId', virta_arvo_id,
+        'johdonsuojaAutomaatti', johdonsuoja_automaatti,
+        'ryhmakaapelityyppi', ryhmakaapelityyppi
+    ),
+    yksilointitieto::uuid, metatieto, alkuhetki, loppuhetki,
+    kunta_id,
+    luonti_pvm, muokkaus_pvm, datan_luoja, muokkaaja,
+    is_deleted
+FROM kohteet.ryhmasulake
+ON CONFLICT DO NOTHING;
+
+GET DIAGNOSTICS v_migrated = ROW_COUNT;
+RAISE NOTICE 'ryhmasulake: migrated % of % records', v_migrated, v_total;
+
+-- Note: ryhmasulake has no junction tables for attachments, contracts,
+-- plan links, or maintenance actions in the legacy schema.
+
+-- ============================================================================
+-- MIGRATION SUMMARY
+-- ============================================================================
+RAISE NOTICE '========================================';
+RAISE NOTICE 'Legacy equipment migration complete.';
+RAISE NOTICE '========================================';
+
+END $migrate_legacy$;

--- a/Scripts/061_update_geometry_triggers_for_equipment.sql
+++ b/Scripts/061_update_geometry_triggers_for_equipment.sql
@@ -1,0 +1,471 @@
+-- ============================================================================
+-- 061_update_geometry_triggers_for_equipment.sql
+-- Adds geometry relation triggers for the kohteet.equipment table.
+-- The equipment table uses different column names than abstractvaruste:
+--   geom_point (not geom_piste), geom_polygon (not geom_poly),
+--   geom_line (same), valid_to (not loppuhetki),
+--   street_area_part_id (not kuuluukatualueenosaan),
+--   green_area_part_id (not kuuluuviheralueenosaan).
+-- Therefore a dedicated trigger function is needed.
+-- ============================================================================
+
+-- Per-row trigger: assigns street_area_part_id and green_area_part_id
+-- based on spatial containment, matching the pattern from
+-- geom_relations_for_each_row() but using equipment column names.
+CREATE OR REPLACE FUNCTION kohteet.equipment_geom_relations_for_each_row()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    target record;
+    v_belongs_to_id integer;
+BEGIN
+    FOR target IN
+        SELECT 'katualueenosa' AS target_table, 'street_area_part_id' AS target_column
+            UNION ALL
+        SELECT 'viheralueenosa' AS target_table, 'green_area_part_id' AS target_column
+    LOOP
+        EXECUTE FORMAT('
+            SELECT alueenosa.id
+            FROM kohteet.%I alueenosa
+            WHERE
+                (
+                    CASE
+                        WHEN $1 IS NOT NULL THEN
+                            ST_Contains(alueenosa.geom, $1)
+                            OR ST_Touches(alueenosa.geom, $1)
+                        WHEN $2 IS NOT NULL THEN
+                            alueenosa.geom && $2
+                            AND ST_Relate(alueenosa.geom, $2, ''******FF*'')
+                        WHEN $3 IS NOT NULL THEN
+                            ST_Contains(alueenosa.geom, $3)
+                        ELSE
+                            FALSE
+                    END
+                )
+                AND (alueenosa.loppuhetki IS NULL OR NOW() < alueenosa.loppuhetki)
+                AND ($4 IS NULL OR NOW() < $4)
+            ORDER BY alueenosa.id DESC
+            LIMIT 1
+        ', target.target_table)
+        USING NEW.geom_point, NEW.geom_line, NEW.geom_polygon, NEW.valid_to
+        INTO v_belongs_to_id;
+
+        IF target.target_column = 'street_area_part_id' THEN
+            NEW.street_area_part_id := v_belongs_to_id;
+        ELSIF target.target_column = 'green_area_part_id' THEN
+            NEW.green_area_part_id := v_belongs_to_id;
+        END IF;
+
+    END LOOP;
+    RETURN NEW;
+END;
+$function$;
+
+ALTER FUNCTION kohteet.equipment_geom_relations_for_each_row() OWNER TO $DatabaseOwner$;
+
+-- Per-row trigger: fires before INSERT or UPDATE of geometry/validity columns
+CREATE TRIGGER equipment_geom_relations_for_each_row
+    BEFORE INSERT OR UPDATE OF geom_point, geom_line, geom_polygon, valid_to
+    ON kohteet.equipment
+    FOR EACH ROW
+    EXECUTE FUNCTION kohteet.equipment_geom_relations_for_each_row();
+
+-- Statement-level trigger: updates equipment area relations when
+-- katualueenosa or viheralueenosa geometries change.
+-- We also add 'equipment' to the existing geom_relations() function's
+-- table name check so it processes equipment rows too.
+
+-- Update the existing geom_relations() function to also handle equipment
+CREATE OR REPLACE FUNCTION kohteet.geom_relations()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    table_name TEXT;
+    updated_count int;
+BEGIN
+    table_name := TG_TABLE_NAME;
+    IF table_name IN ('keskilinja', 'viheralueenosa', 'katualueenosa',
+                      'ajoratamerkinta', 'hulevesi', 'jate', 'kaapeli', 'kaluste', 'leikkivaline', 'liikennemerkki',
+                      'liikunta', 'melu', 'muuvaruste', 'opaste', 'pysakointiruutu', 'rakenne', 'valaisin',
+                      'valaisinkeskus', 'ymparistotaide',
+                      'equipment') THEN
+
+        --
+        -- Case 1: add/update current kuuluukatualueeseen relations
+        --
+        UPDATE kohteet.keskilinja SET kuuluukatualueenosaan = katualueenosa.id
+            FROM kohteet.katualueenosa
+            WHERE ST_Contains(katualueenosa.geom, keskilinja.geom)
+              AND (katualueenosa.loppuhetki IS NULL OR NOW() < katualueenosa.loppuhetki);
+        GET DIAGNOSTICS updated_count = ROW_COUNT;
+
+        RAISE NOTICE 'updated % keskilinja ==> katualueenosa relations', updated_count;
+
+        --
+        -- Case 1a: add/update current kuuluukatualueeseen relations
+        --
+        UPDATE kohteet.abstractvaruste varuste SET kuuluukatualueenosaan = katualueenosa.id
+            FROM kohteet.katualueenosa
+            WHERE (
+                ST_Contains(katualueenosa.geom, varuste.geom_piste)
+                OR ST_Contains(katualueenosa.geom, varuste.geom_line)
+                OR ST_Contains(katualueenosa.geom, varuste.geom_poly)
+            ) AND (katualueenosa.loppuhetki IS NULL OR NOW() < katualueenosa.loppuhetki)
+              AND (varuste.loppuhetki       IS NULL OR NOW() < varuste.loppuhetki);
+        GET DIAGNOSTICS updated_count = ROW_COUNT;
+        RAISE NOTICE 'updated % relations for varuste ==> katualueenosa relations (triggered by %)', updated_count, table_name;
+
+        --
+        -- Case 1a-eq: add/update equipment ==> katualueenosa relations
+        --
+        UPDATE kohteet.equipment eq SET street_area_part_id = katualueenosa.id
+            FROM kohteet.katualueenosa
+            WHERE (
+                ST_Contains(katualueenosa.geom, eq.geom_point)
+                OR ST_Contains(katualueenosa.geom, eq.geom_line)
+                OR ST_Contains(katualueenosa.geom, eq.geom_polygon)
+            ) AND (katualueenosa.loppuhetki IS NULL OR NOW() < katualueenosa.loppuhetki)
+              AND (eq.valid_to IS NULL OR NOW() < eq.valid_to);
+        GET DIAGNOSTICS updated_count = ROW_COUNT;
+        RAISE NOTICE 'updated % relations for equipment ==> katualueenosa relations (triggered by %)', updated_count, table_name;
+
+        --
+        -- Case 1b: add/update current kuuluuviheralueeseen relations
+        --
+        UPDATE kohteet.abstractvaruste varuste SET kuuluuviheralueenosaan = viheralueenosa.id
+            FROM kohteet.viheralueenosa
+            WHERE (
+                ST_Contains(viheralueenosa.geom, varuste.geom_piste)
+                OR ST_Contains(viheralueenosa.geom, varuste.geom_line)
+                OR ST_Contains(viheralueenosa.geom, varuste.geom_poly)
+            ) AND (viheralueenosa.loppuhetki IS NULL OR NOW() < viheralueenosa.loppuhetki)
+              AND (varuste.loppuhetki       IS NULL OR NOW() < varuste.loppuhetki);
+        GET DIAGNOSTICS updated_count = ROW_COUNT;
+        RAISE NOTICE 'updated % relations for varuste ==> viheralueenosa relations (triggered by %)', updated_count, table_name;
+
+        --
+        -- Case 1b-eq: add/update equipment ==> viheralueenosa relations
+        --
+        UPDATE kohteet.equipment eq SET green_area_part_id = viheralueenosa.id
+            FROM kohteet.viheralueenosa
+            WHERE (
+                ST_Contains(viheralueenosa.geom, eq.geom_point)
+                OR ST_Contains(viheralueenosa.geom, eq.geom_line)
+                OR ST_Contains(viheralueenosa.geom, eq.geom_polygon)
+            ) AND (viheralueenosa.loppuhetki IS NULL OR NOW() < viheralueenosa.loppuhetki)
+              AND (eq.valid_to IS NULL OR NOW() < eq.valid_to);
+        GET DIAGNOSTICS updated_count = ROW_COUNT;
+        RAISE NOTICE 'updated % relations for equipment ==> viheralueenosa relations (triggered by %)', updated_count, table_name;
+
+        --
+        -- Case 2: remove expired kuuluukatualueeseen relations
+        --
+        UPDATE kohteet.keskilinja SET kuuluukatualueenosaan = NULL
+            FROM kohteet.katualueenosa
+            WHERE
+              keskilinja.kuuluukatualueenosaan = katualueenosa.id
+              AND NOT (
+                  ST_Contains(katualueenosa.geom, keskilinja.geom)
+                      AND (katualueenosa.loppuhetki IS NULL OR NOW() < katualueenosa.loppuhetki)
+              );
+        GET DIAGNOSTICS updated_count = ROW_COUNT;
+
+        RAISE NOTICE 'removed % keskilinja ==> katualueenosa relations', updated_count;
+
+        --
+        -- Case 2a: remove expired kuuluukatualueeseen relations
+        --
+        UPDATE kohteet.abstractvaruste varuste SET kuuluukatualueenosaan = NULL
+            FROM kohteet.katualueenosa
+            WHERE
+              varuste.kuuluukatualueenosaan = katualueenosa.id
+              AND NOT (
+                (
+                    ST_Contains(katualueenosa.geom, varuste.geom_piste)
+                    OR ST_Contains(katualueenosa.geom, varuste.geom_line)
+                    OR ST_Contains(katualueenosa.geom, varuste.geom_poly)
+                ) AND (katualueenosa.loppuhetki IS NULL OR NOW() < katualueenosa.loppuhetki)
+                  AND (varuste.loppuhetki       IS NULL OR NOW() < varuste.loppuhetki)
+              );
+        GET DIAGNOSTICS updated_count = ROW_COUNT;
+        RAISE NOTICE 'removed % relations from varuste ==> katualueenosa relations (triggered by %)', updated_count, table_name;
+
+        --
+        -- Case 2a-eq: remove expired equipment ==> katualueenosa relations
+        --
+        UPDATE kohteet.equipment eq SET street_area_part_id = NULL
+            FROM kohteet.katualueenosa
+            WHERE
+              eq.street_area_part_id = katualueenosa.id
+              AND NOT (
+                (
+                    ST_Contains(katualueenosa.geom, eq.geom_point)
+                    OR ST_Contains(katualueenosa.geom, eq.geom_line)
+                    OR ST_Contains(katualueenosa.geom, eq.geom_polygon)
+                ) AND (katualueenosa.loppuhetki IS NULL OR NOW() < katualueenosa.loppuhetki)
+                  AND (eq.valid_to IS NULL OR NOW() < eq.valid_to)
+              );
+        GET DIAGNOSTICS updated_count = ROW_COUNT;
+        RAISE NOTICE 'removed % relations from equipment ==> katualueenosa relations (triggered by %)', updated_count, table_name;
+
+        --
+        -- Case 2b: remove expired kuuluuviheralueeseen relations
+        --
+        UPDATE kohteet.abstractvaruste varuste SET kuuluuviheralueenosaan = NULL
+            FROM kohteet.viheralueenosa
+            WHERE
+              varuste.kuuluuviheralueenosaan = viheralueenosa.id
+              AND NOT (
+                (
+                    ST_Contains(viheralueenosa.geom, varuste.geom_piste)
+                    OR ST_Contains(viheralueenosa.geom, varuste.geom_line)
+                    OR ST_Contains(viheralueenosa.geom, varuste.geom_poly)
+                ) AND (viheralueenosa.loppuhetki IS NULL OR NOW() < viheralueenosa.loppuhetki)
+                  AND (varuste.loppuhetki       IS NULL OR NOW() < varuste.loppuhetki)
+              );
+        GET DIAGNOSTICS updated_count = ROW_COUNT;
+        RAISE NOTICE 'removed % relations from varuste ==> viheralueenosa relations (triggered by %)', updated_count, table_name;
+
+        --
+        -- Case 2b-eq: remove expired equipment ==> viheralueenosa relations
+        --
+        UPDATE kohteet.equipment eq SET green_area_part_id = NULL
+            FROM kohteet.viheralueenosa
+            WHERE
+              eq.green_area_part_id = viheralueenosa.id
+              AND NOT (
+                (
+                    ST_Contains(viheralueenosa.geom, eq.geom_point)
+                    OR ST_Contains(viheralueenosa.geom, eq.geom_line)
+                    OR ST_Contains(viheralueenosa.geom, eq.geom_polygon)
+                ) AND (viheralueenosa.loppuhetki IS NULL OR NOW() < viheralueenosa.loppuhetki)
+                  AND (eq.valid_to IS NULL OR NOW() < eq.valid_to)
+              );
+        GET DIAGNOSTICS updated_count = ROW_COUNT;
+        RAISE NOTICE 'removed % relations from equipment ==> viheralueenosa relations (triggered by %)', updated_count, table_name;
+    END IF;
+
+    RETURN NULL;
+END;
+$function$;
+
+-- Statement-level trigger on equipment table
+CREATE TRIGGER equipment_geom_relations
+    AFTER INSERT OR UPDATE OF geom_point, geom_line, geom_polygon, valid_to
+    ON kohteet.equipment
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION kohteet.geom_relations();
+
+-- Also update geom_relations_for_each_row() to handle equipment in the
+-- viheralueenosa/katualueenosa branch (when area geometry changes,
+-- update equipment rows too)
+CREATE OR REPLACE FUNCTION kohteet.geom_relations_for_each_row()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    target record;
+    table_name TEXT;
+    abstract_table_name TEXT;
+    target_column TEXT;
+    updated_count int;
+    update_relation_sql text;
+    remove_relation_sql text;
+    v_belongs_to_id integer;
+BEGIN
+    table_name := TG_TABLE_NAME;
+    IF table_name IN ('viheralueenosa', 'katualueenosa') THEN
+        IF table_name = 'viheralueenosa' THEN
+            target_column := 'kuuluuviheralueenosaan';
+        ELSE
+            target_column := 'kuuluukatualueenosaan';
+        END IF;
+
+        FOREACH abstract_table_name IN ARRAY ARRAY['abstractvaruste', 'abstractkasvillisuus']
+        LOOP
+            update_relation_sql := FORMAT('
+                UPDATE kohteet.%I kohde
+                SET %I = alueenosa.id
+                FROM kohteet.%I alueenosa
+                WHERE
+                    alueenosa.id = %s
+                    And (
+                        ST_Contains(alueenosa.geom, kohde.geom_piste)
+                        OR ST_Touches(alueenosa.geom, kohde.geom_piste)
+                        OR (
+                            alueenosa.geom && kohde.geom_line
+                            AND ST_Relate(alueenosa.geom, kohde.geom_line, ''******FF*'')
+                        )
+                        OR ST_Contains(alueenosa.geom, kohde.geom_poly)
+                    )
+                    AND (alueenosa.loppuhetki IS NULL OR NOW() < alueenosa.loppuhetki)
+                    AND (kohde.loppuhetki IS NULL OR NOW() < kohde.loppuhetki)
+            ', abstract_table_name, target_column, table_name, NEW.id);
+            EXECUTE update_relation_sql;
+
+            remove_relation_sql := FORMAT('
+                UPDATE kohteet.%I kohde
+                SET %I = NULL
+                FROM kohteet.%I alueenosa
+                WHERE
+                    kohde.kuuluuviheralueenosaan = alueenosa.id
+                    AND alueenosa.id = %s
+                    AND NOT (
+                        (
+                            ST_Contains(alueenosa.geom, kohde.geom_piste)
+                            OR ST_Touches(alueenosa.geom, kohde.geom_piste)
+                            OR (
+                                alueenosa.geom && kohde.geom_line
+                                AND ST_Relate(alueenosa.geom, kohde.geom_line, ''******FF*'')
+                            )
+                            OR ST_Contains(alueenosa.geom, kohde.geom_poly)
+                        )
+                        AND (alueenosa.loppuhetki IS NULL OR NOW() < alueenosa.loppuhetki)
+                        AND (kohde.loppuhetki       IS NULL OR NOW() < kohde.loppuhetki)
+                    )
+            ', abstract_table_name, target_column, table_name, NEW.id);
+            EXECUTE remove_relation_sql;
+        END LOOP;
+
+        -- Also update equipment table (uses different column names)
+        IF table_name = 'katualueenosa' THEN
+            EXECUTE FORMAT('
+                UPDATE kohteet.equipment eq
+                SET street_area_part_id = alueenosa.id
+                FROM kohteet.katualueenosa alueenosa
+                WHERE
+                    alueenosa.id = %s
+                    AND (
+                        ST_Contains(alueenosa.geom, eq.geom_point)
+                        OR ST_Touches(alueenosa.geom, eq.geom_point)
+                        OR (
+                            alueenosa.geom && eq.geom_line
+                            AND ST_Relate(alueenosa.geom, eq.geom_line, ''******FF*'')
+                        )
+                        OR ST_Contains(alueenosa.geom, eq.geom_polygon)
+                    )
+                    AND (alueenosa.loppuhetki IS NULL OR NOW() < alueenosa.loppuhetki)
+                    AND (eq.valid_to IS NULL OR NOW() < eq.valid_to)
+            ', NEW.id);
+
+            EXECUTE FORMAT('
+                UPDATE kohteet.equipment eq
+                SET street_area_part_id = NULL
+                FROM kohteet.katualueenosa alueenosa
+                WHERE
+                    eq.street_area_part_id = alueenosa.id
+                    AND alueenosa.id = %s
+                    AND NOT (
+                        (
+                            ST_Contains(alueenosa.geom, eq.geom_point)
+                            OR ST_Touches(alueenosa.geom, eq.geom_point)
+                            OR (
+                                alueenosa.geom && eq.geom_line
+                                AND ST_Relate(alueenosa.geom, eq.geom_line, ''******FF*'')
+                            )
+                            OR ST_Contains(alueenosa.geom, eq.geom_polygon)
+                        )
+                        AND (alueenosa.loppuhetki IS NULL OR NOW() < alueenosa.loppuhetki)
+                        AND (eq.valid_to IS NULL OR NOW() < eq.valid_to)
+                    )
+            ', NEW.id);
+        ELSIF table_name = 'viheralueenosa' THEN
+            EXECUTE FORMAT('
+                UPDATE kohteet.equipment eq
+                SET green_area_part_id = alueenosa.id
+                FROM kohteet.viheralueenosa alueenosa
+                WHERE
+                    alueenosa.id = %s
+                    AND (
+                        ST_Contains(alueenosa.geom, eq.geom_point)
+                        OR ST_Touches(alueenosa.geom, eq.geom_point)
+                        OR (
+                            alueenosa.geom && eq.geom_line
+                            AND ST_Relate(alueenosa.geom, eq.geom_line, ''******FF*'')
+                        )
+                        OR ST_Contains(alueenosa.geom, eq.geom_polygon)
+                    )
+                    AND (alueenosa.loppuhetki IS NULL OR NOW() < alueenosa.loppuhetki)
+                    AND (eq.valid_to IS NULL OR NOW() < eq.valid_to)
+            ', NEW.id);
+
+            EXECUTE FORMAT('
+                UPDATE kohteet.equipment eq
+                SET green_area_part_id = NULL
+                FROM kohteet.viheralueenosa alueenosa
+                WHERE
+                    eq.green_area_part_id = alueenosa.id
+                    AND alueenosa.id = %s
+                    AND NOT (
+                        (
+                            ST_Contains(alueenosa.geom, eq.geom_point)
+                            OR ST_Touches(alueenosa.geom, eq.geom_point)
+                            OR (
+                                alueenosa.geom && eq.geom_line
+                                AND ST_Relate(alueenosa.geom, eq.geom_line, ''******FF*'')
+                            )
+                            OR ST_Contains(alueenosa.geom, eq.geom_polygon)
+                        )
+                        AND (alueenosa.loppuhetki IS NULL OR NOW() < alueenosa.loppuhetki)
+                        AND (eq.valid_to IS NULL OR NOW() < eq.valid_to)
+                    )
+            ', NEW.id);
+        END IF;
+
+        RETURN NEW;
+    END IF;
+
+    IF table_name IN ('ajoratamerkinta', 'hulevesi', 'jate', 'kaapeli', 'kaluste', 'leikkivaline', 'liikennemerkki',
+                      'liikunta', 'melu', 'muuvaruste', 'opaste', 'pysakointiruutu', 'rakenne', 'valaisin',
+                      'valaisinkeskus', 'ymparistotaide',
+                      'puu', 'muukasvi') THEN
+        --
+        -- Case 1: add/update current kuuluukatualueeseen/kuuluuviheralueeseen relations
+        --
+        FOR target IN
+            SELECT 'katualueenosa' AS target_table, 'kuuluukatualueenosaan' AS target_column
+                UNION ALL
+            SELECT 'viheralueenosa' AS target_table, 'kuuluuviheralueenosaan' AS target_column
+        LOOP
+            EXECUTE FORMAT('
+                SELECT alueenosa.id
+                FROM kohteet.%I alueenosa
+                WHERE
+                    (
+                        CASE
+                            WHEN $1 IS NOT NULL THEN
+                                ST_Contains(alueenosa.geom, $1)
+                                OR ST_Touches(alueenosa.geom, $1)
+                            WHEN $2 IS NOT NULL THEN
+                                alueenosa.geom && $2
+                                AND ST_Relate(alueenosa.geom, $2, ''******FF*'')
+                            WHEN $3 IS NOT NULL THEN
+                                ST_Contains(alueenosa.geom, $3)
+                            ELSE
+                                FALSE
+                        END
+                    )
+                    AND (alueenosa.loppuhetki IS NULL OR NOW() < alueenosa.loppuhetki)
+                    AND ($4 IS NULL OR NOW() < $4)
+                ORDER BY alueenosa.id DESC
+                LIMIT 1
+            ', target.target_table)
+            USING NEW.geom_piste, NEW.geom_line, NEW.geom_poly, NEW.loppuhetki
+            INTO v_belongs_to_id;
+
+
+            IF target.target_column = 'kuuluukatualueenosaan' THEN
+                NEW.kuuluukatualueenosaan := v_belongs_to_id;
+            ELSIF target.target_column = 'kuuluuviheralueenosaan' THEN
+                NEW.kuuluuviheralueenosaan := v_belongs_to_id;
+            END IF;
+
+        END LOOP;
+        RETURN NEW;
+    END IF;
+
+    RETURN NULL;
+END;
+$function$;

--- a/Scripts/062_add_valaisinkeskus_equipment_type.sql
+++ b/Scripts/062_add_valaisinkeskus_equipment_type.sql
@@ -1,0 +1,101 @@
+-- Add missing valaisinkeskus equipment type and migrate legacy data
+-- valaisinkeskus was omitted from the initial equipment_type seed in 059
+
+-- 1. Add equipment type
+INSERT INTO kohteet.equipment_type (id, name, sort_order) VALUES (17, 'valaisinkeskus', 17)
+ON CONFLICT DO NOTHING;
+
+-- 2. Migrate legacy valaisinkeskus data to equipment table
+DO $$
+DECLARE
+    v_total integer;
+    v_migrated integer;
+BEGIN
+
+SELECT count(*) INTO v_total FROM kohteet.valaisinkeskus;
+
+INSERT INTO kohteet.equipment (
+    equipment_type_id, properties,
+    geom_point, geom_line, geom_polygon,
+    uuid, metadata, valid_from, valid_to,
+    model, manufacture_year, renovation_year,
+    manufacturer, owner, holder, maintainer,
+    location_uncertainty_id, creation_method_id,
+    address_id, material_id,
+    lifecycle_id, condition_id, status_id,
+    municipality_id,
+    additional_info, surveyor,
+    street_area_part_id, green_area_part_id,
+    created_at, modified_at, created_by, modified_by,
+    is_deleted
+)
+SELECT
+    17,
+    jsonb_build_object(
+        'nimi', nimi,
+        'kayttopaikanNumero', kayttopaikan_numero,
+        'valaisinkeskusTyyppiId', valaisinkeskus_tyyppi_id,
+        'valaisinkeskusLukitusId', lukitus_id,
+        'kilpiarvo', kilpiarvo,
+        'valaisinkeskusPaasulakeId', paasulake_id,
+        'valaisinkeskusPaasulakeTyyppiId', paasulake_tyyppi_id,
+        'mittarinumero', mittarinumero,
+        'yosammutus', yosammutus,
+        'energiayhtio', energiayhtio,
+        'energiayhtionNumero', energiayhtion_numero,
+        'valaisinkeskusMittarointiId', mittarointi_id,
+        'syottokaapelienLkm', syottokaapelien_lkm,
+        'valaisinkeskusOhjaustapaId', ohjaustapa_id,
+        'ohjaustunnus', ohjaustunnus,
+        'maxLahtoja', max_lahtoja,
+        'mitattuOikosulkuvirta', mitattu_oikosulkuvirta,
+        'mittauspaiva', mittauspaiva
+    ),
+    geom_piste, geom_line, geom_poly,
+    yksilointitieto::uuid, metatieto, alkuhetki, loppuhetki,
+    malli, valmistumisvuosi, perusparannusvuosi,
+    valmistaja, omistaja, haltija, kunnossapitaja,
+    sijaintiepavarmuus_id, luontitapa_id,
+    osoite_id, materiaali_id,
+    elinkaari_id, kunto_id, tila_id,
+    kunta_id,
+    lisatietoja, inventoija,
+    kuuluukatualueenosaan, kuuluuviheralueenosaan,
+    luonti_pvm, muokkaus_pvm, datan_luoja, muokkaaja,
+    is_deleted
+FROM kohteet.valaisinkeskus
+ON CONFLICT DO NOTHING;
+
+GET DIAGNOSTICS v_migrated = ROW_COUNT;
+RAISE NOTICE 'valaisinkeskus: migrated % of % records', v_migrated, v_total;
+
+END $$;
+
+-- 3. Migrate junction table relationships
+INSERT INTO kohteet.equipment_attachment (equipment_id, attachment_id)
+SELECT e.id, vl.liite_id
+FROM kohteet.valaisinkeskus_liite vl
+JOIN kohteet.valaisinkeskus v ON v.id = vl.valaisinkeskus_id
+JOIN kohteet.equipment e ON e.uuid = v.yksilointitieto::uuid AND e.equipment_type_id = 17
+ON CONFLICT DO NOTHING;
+
+INSERT INTO kohteet.equipment_contract (equipment_id, contract_id)
+SELECT e.id, vu.urakka_id
+FROM kohteet.valaisinkeskus_urakka vu
+JOIN kohteet.valaisinkeskus v ON v.id = vu.valaisinkeskus_id
+JOIN kohteet.equipment e ON e.uuid = v.yksilointitieto::uuid AND e.equipment_type_id = 17
+ON CONFLICT DO NOTHING;
+
+INSERT INTO kohteet.equipment_plan_link (equipment_id, plan_link_id)
+SELECT e.id, vs.suunnitelmalinkki_id
+FROM kohteet.valaisinkeskus_suunnitelmalinkki vs
+JOIN kohteet.valaisinkeskus v ON v.id = vs.valaisinkeskus_id
+JOIN kohteet.equipment e ON e.uuid = v.yksilointitieto::uuid AND e.equipment_type_id = 17
+ON CONFLICT DO NOTHING;
+
+INSERT INTO kohteet.equipment_maintenance_action (equipment_id, maintenance_action_id)
+SELECT e.id, vvt.varuste_toimenpide_id
+FROM kohteet.valaisinkeskus_varuste_toimenpide_linkki vvt
+JOIN kohteet.valaisinkeskus v ON v.id = vvt.valaisinkeskus_id
+JOIN kohteet.equipment e ON e.uuid = v.yksilointitieto::uuid AND e.equipment_type_id = 17
+ON CONFLICT DO NOTHING;

--- a/Scripts/063_remove_ryhmasulake_from_equipment_type.sql
+++ b/Scripts/063_remove_ryhmasulake_from_equipment_type.sql
@@ -1,0 +1,26 @@
+-- ============================================================================
+-- 063_remove_ryhmasulake_from_equipment_type.sql
+-- Removes ryhmasulake (id=6) from the generic equipment model.
+-- Ryhmasulake inherits from abstractinfraomaisuuskohde, NOT abstractvaruste,
+-- and is handled via InfraomaisuuskohdeController / InfraomaisuuskohdeRepository.
+-- It was incorrectly included in the equipment_type registry and migration.
+-- ============================================================================
+
+-- Remove junction table rows for any migrated ryhmasulake equipment records
+DELETE FROM kohteet.equipment_maintenance_action
+WHERE equipment_id IN (SELECT id FROM kohteet.equipment WHERE equipment_type_id = 6);
+
+DELETE FROM kohteet.equipment_plan_link
+WHERE equipment_id IN (SELECT id FROM kohteet.equipment WHERE equipment_type_id = 6);
+
+DELETE FROM kohteet.equipment_contract
+WHERE equipment_id IN (SELECT id FROM kohteet.equipment WHERE equipment_type_id = 6);
+
+DELETE FROM kohteet.equipment_attachment
+WHERE equipment_id IN (SELECT id FROM kohteet.equipment WHERE equipment_type_id = 6);
+
+-- Remove migrated ryhmasulake rows from the equipment table
+DELETE FROM kohteet.equipment WHERE equipment_type_id = 6;
+
+-- Remove the equipment_type code list entry
+DELETE FROM kohteet.equipment_type WHERE id = 6;

--- a/Scripts/064_equipment_uuid_unique_index.sql
+++ b/Scripts/064_equipment_uuid_unique_index.sql
@@ -1,0 +1,5 @@
+-- Replace non-unique index on equipment.uuid with a UNIQUE index
+-- to prevent duplicate UUIDs from being inserted.
+
+DROP INDEX IF EXISTS kohteet.idx_equipment_uuid;
+CREATE UNIQUE INDEX idx_equipment_uuid ON kohteet.equipment(uuid);


### PR DESCRIPTION
Replaces per-type varuste tables with a single equipment table using JSONB for type-specific properties. Adding new equipment types no longer requires schema changes.

Scripts
059 — equipment_type code list (16 types), equipment table, indexes (B-tree, GIN, GIST), 4 junction tables
060 — Migrates legacy data (hulevesi, jate, valaisin, liikennemerkki, kaapeli, ryhmasulake) into the generic table via jsonb_build_object(). Idempotent (ON CONFLICT DO NOTHING).
061 — Adds equipment to geometry trigger functions
062 — Adds valaisinkeskus (type 17, omitted from 059)
063 — Removes ryhmasulake from equipment types (it's an infraomaisuuskohde)
064 — Makes UUID index UNIQUE