### PR TITLE
Feature/infraregistry 293 add relations between equipments

### DIFF
--- a/Scripts/065_create_equipment_relationship.sql
+++ b/Scripts/065_create_equipment_relationship.sql
@@ -1,0 +1,63 @@
+-- Create equipment relationship tables for equipment-to-equipment connections.
+-- Replaces legacy FK relationships (valaisin→valaisinkeskus, etc.) and
+-- junction tables (liikennemerkki_liikennemerkki_linkki) with a generic
+-- relationship model supporting both directional and bidirectional connections.
+
+-- ============================================================================
+-- 1. EQUIPMENT_RELATIONSHIP_TYPE code list table
+-- ============================================================================
+
+CREATE TABLE kohteet.equipment_relationship_type (
+    id          INTEGER PRIMARY KEY,
+    name        TEXT NOT NULL,
+    direction   TEXT NOT NULL CHECK (direction IN ('directional', 'bidirectional')),
+    sort_order  INTEGER
+);
+ALTER TABLE kohteet.equipment_relationship_type OWNER TO $DatabaseOwner$;
+
+-- Seed initial relationship types
+INSERT INTO kohteet.equipment_relationship_type (id, name, direction, sort_order) VALUES
+    (1, 'belongs_to_center', 'directional',   1),
+    (2, 'co_located',        'bidirectional', 2),
+    (3, 'connected_to',      'bidirectional', 3),
+    (4, 'mounted_on',        'directional',   4),
+    (5, 'part_of',           'directional',   5);
+
+-- ============================================================================
+-- 2. EQUIPMENT_RELATIONSHIP junction table
+-- ============================================================================
+
+CREATE TABLE kohteet.equipment_relationship (
+    id                      SERIAL PRIMARY KEY,
+    source_equipment_id     INTEGER NOT NULL REFERENCES kohteet.equipment(id)
+                            ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    target_equipment_id     INTEGER NOT NULL REFERENCES kohteet.equipment(id)
+                            ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    relationship_type_id    INTEGER NOT NULL REFERENCES kohteet.equipment_relationship_type(id)
+                            ON DELETE RESTRICT ON UPDATE CASCADE,
+
+    -- Unique constraint: no duplicate relationships
+    CONSTRAINT uq_equipment_relationship
+        UNIQUE (source_equipment_id, target_equipment_id, relationship_type_id),
+
+    -- Audit fields
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    modified_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by              VARCHAR(200) NOT NULL,
+    modified_by             VARCHAR(200) NOT NULL
+);
+ALTER TABLE kohteet.equipment_relationship OWNER TO $DatabaseOwner$;
+
+-- ============================================================================
+-- 3. Indexes for efficient lookup
+-- ============================================================================
+
+-- B-tree indexes on source and target for efficient lookup from either side
+CREATE INDEX idx_equipment_relationship_source
+    ON kohteet.equipment_relationship(source_equipment_id);
+CREATE INDEX idx_equipment_relationship_target
+    ON kohteet.equipment_relationship(target_equipment_id);
+
+-- Composite index for filtered queries by source + type
+CREATE INDEX idx_equipment_relationship_source_type
+    ON kohteet.equipment_relationship(source_equipment_id, relationship_type_id);

--- a/Scripts/066_migrate_legacy_relationships.sql
+++ b/Scripts/066_migrate_legacy_relationships.sql
@@ -1,0 +1,143 @@
+-- Migrate legacy FK relationships and junction table records to equipment_relationship.
+-- Depends on:
+--   059: equipment and equipment_type tables exist
+--   060: Legacy equipment data migrated to equipment table
+--   062: valaisinkeskus added to equipment_type (id=17) and data migrated
+--   065: equipment_relationship and equipment_relationship_type tables exist
+
+DO $$
+DECLARE
+    v_migrated   INTEGER;
+    v_total      INTEGER;
+BEGIN
+
+-- ============================================================================
+-- 1. VALAISIN → VALAISINKESKUS (belongs_to_center, type_id=1)
+-- ============================================================================
+SELECT count(*) INTO v_total
+FROM kohteet.valaisin v
+WHERE v.valaisinkeskus_id IS NOT NULL;
+
+INSERT INTO kohteet.equipment_relationship (
+    source_equipment_id, target_equipment_id, relationship_type_id,
+    created_at, modified_at, created_by, modified_by
+)
+SELECT
+    e_src.id,
+    e_tgt.id,
+    1,
+    NOW(), NOW(), 'migration', 'migration'
+FROM kohteet.valaisin v
+JOIN kohteet.equipment e_src
+    ON e_src.uuid = v.yksilointitieto::uuid AND e_src.equipment_type_id = 3
+JOIN kohteet.valaisinkeskus vk ON vk.id = v.valaisinkeskus_id
+JOIN kohteet.equipment e_tgt
+    ON e_tgt.uuid = vk.yksilointitieto::uuid AND e_tgt.equipment_type_id = 17
+WHERE v.valaisinkeskus_id IS NOT NULL
+ON CONFLICT ON CONSTRAINT uq_equipment_relationship DO NOTHING;
+
+GET DIAGNOSTICS v_migrated = ROW_COUNT;
+RAISE NOTICE 'valaisin→valaisinkeskus: migrated % of % relationships', v_migrated, v_total;
+
+-- ============================================================================
+-- 2. RYHMASULAKE → VALAISINKESKUS (belongs_to_center, type_id=1)
+-- ============================================================================
+SELECT count(*) INTO v_total
+FROM kohteet.ryhmasulake r
+WHERE r.valaisinkeskus_id IS NOT NULL;
+
+INSERT INTO kohteet.equipment_relationship (
+    source_equipment_id, target_equipment_id, relationship_type_id,
+    created_at, modified_at, created_by, modified_by
+)
+SELECT
+    e_src.id,
+    e_tgt.id,
+    1,
+    NOW(), NOW(), 'migration', 'migration'
+FROM kohteet.ryhmasulake r
+JOIN kohteet.equipment e_src
+    ON e_src.uuid = r.yksilointitieto::uuid AND e_src.equipment_type_id = 6
+JOIN kohteet.valaisinkeskus vk ON vk.id = r.valaisinkeskus_id
+JOIN kohteet.equipment e_tgt
+    ON e_tgt.uuid = vk.yksilointitieto::uuid AND e_tgt.equipment_type_id = 17
+WHERE r.valaisinkeskus_id IS NOT NULL
+ON CONFLICT ON CONSTRAINT uq_equipment_relationship DO NOTHING;
+
+GET DIAGNOSTICS v_migrated = ROW_COUNT;
+RAISE NOTICE 'ryhmasulake→valaisinkeskus: migrated % of % relationships', v_migrated, v_total;
+
+-- ============================================================================
+-- 3. KAAPELI → VALAISINKESKUS (belongs_to_center, type_id=1)
+-- ============================================================================
+SELECT count(*) INTO v_total
+FROM kohteet.kaapeli k
+WHERE k.valaisinkeskus_id IS NOT NULL;
+
+INSERT INTO kohteet.equipment_relationship (
+    source_equipment_id, target_equipment_id, relationship_type_id,
+    created_at, modified_at, created_by, modified_by
+)
+SELECT
+    e_src.id,
+    e_tgt.id,
+    1,
+    NOW(), NOW(), 'migration', 'migration'
+FROM kohteet.kaapeli k
+JOIN kohteet.equipment e_src
+    ON e_src.uuid = k.yksilointitieto::uuid AND e_src.equipment_type_id = 5
+JOIN kohteet.valaisinkeskus vk ON vk.id = k.valaisinkeskus_id
+JOIN kohteet.equipment e_tgt
+    ON e_tgt.uuid = vk.yksilointitieto::uuid AND e_tgt.equipment_type_id = 17
+WHERE k.valaisinkeskus_id IS NOT NULL
+ON CONFLICT ON CONSTRAINT uq_equipment_relationship DO NOTHING;
+
+GET DIAGNOSTICS v_migrated = ROW_COUNT;
+RAISE NOTICE 'kaapeli→valaisinkeskus: migrated % of % relationships', v_migrated, v_total;
+
+-- ============================================================================
+-- 4. LIIKENNEMERKKI ↔ LIIKENNEMERKKI (co_located, type_id=2, bidirectional)
+-- ============================================================================
+SELECT count(*) INTO v_total
+FROM kohteet.liikennemerkki_liikennemerkki_linkki;
+
+INSERT INTO kohteet.equipment_relationship (
+    source_equipment_id, target_equipment_id, relationship_type_id,
+    created_at, modified_at, created_by, modified_by
+)
+SELECT
+    e1.id,
+    e2.id,
+    2,
+    NOW(), NOW(), 'migration', 'migration'
+FROM kohteet.liikennemerkki_liikennemerkki_linkki lll
+JOIN kohteet.liikennemerkki lm1 ON lm1.id = lll.liikennemerkki_id1
+JOIN kohteet.equipment e1
+    ON e1.uuid = lm1.yksilointitieto::uuid AND e1.equipment_type_id = 4
+JOIN kohteet.liikennemerkki lm2 ON lm2.id = lll.liikennemerkki_id2
+JOIN kohteet.equipment e2
+    ON e2.uuid = lm2.yksilointitieto::uuid AND e2.equipment_type_id = 4
+ON CONFLICT ON CONSTRAINT uq_equipment_relationship DO NOTHING;
+
+GET DIAGNOSTICS v_migrated = ROW_COUNT;
+RAISE NOTICE 'liikennemerkki↔liikennemerkki: migrated % of % relationships', v_migrated, v_total;
+
+-- ============================================================================
+-- 5. Remove valaisinkeskusId from JSONB properties
+-- ============================================================================
+UPDATE kohteet.equipment
+SET properties = properties - 'valaisinkeskusId',
+    modified_at = NOW(),
+    modified_by = 'migration'
+WHERE equipment_type_id IN (3, 5, 6)
+  AND properties ? 'valaisinkeskusId';
+
+GET DIAGNOSTICS v_migrated = ROW_COUNT;
+RAISE NOTICE 'Removed valaisinkeskusId from % equipment JSONB records', v_migrated;
+
+-- ============================================================================
+RAISE NOTICE '========================================';
+RAISE NOTICE 'Legacy relationship migration complete.';
+RAISE NOTICE '========================================';
+
+END $$;

--- a/Scripts/066_migrate_legacy_relationships.sql
+++ b/Scripts/066_migrate_legacy_relationships.sql
@@ -4,6 +4,9 @@
 --   060: Legacy equipment data migrated to equipment table
 --   062: valaisinkeskus added to equipment_type (id=17) and data migrated
 --   065: equipment_relationship and equipment_relationship_type tables exist
+--
+-- Note: All INSERT queries filter out soft-deleted equipment (is_deleted = false)
+-- to avoid creating relationships pointing to logically removed records.
 
 DO $$
 DECLARE
@@ -34,6 +37,8 @@ JOIN kohteet.valaisinkeskus vk ON vk.id = v.valaisinkeskus_id
 JOIN kohteet.equipment e_tgt
     ON e_tgt.uuid = vk.yksilointitieto::uuid AND e_tgt.equipment_type_id = 17
 WHERE v.valaisinkeskus_id IS NOT NULL
+  AND e_src.is_deleted = false
+  AND e_tgt.is_deleted = false
 ON CONFLICT ON CONSTRAINT uq_equipment_relationship DO NOTHING;
 
 GET DIAGNOSTICS v_migrated = ROW_COUNT;
@@ -62,6 +67,8 @@ JOIN kohteet.valaisinkeskus vk ON vk.id = r.valaisinkeskus_id
 JOIN kohteet.equipment e_tgt
     ON e_tgt.uuid = vk.yksilointitieto::uuid AND e_tgt.equipment_type_id = 17
 WHERE r.valaisinkeskus_id IS NOT NULL
+  AND e_src.is_deleted = false
+  AND e_tgt.is_deleted = false
 ON CONFLICT ON CONSTRAINT uq_equipment_relationship DO NOTHING;
 
 GET DIAGNOSTICS v_migrated = ROW_COUNT;
@@ -90,6 +97,8 @@ JOIN kohteet.valaisinkeskus vk ON vk.id = k.valaisinkeskus_id
 JOIN kohteet.equipment e_tgt
     ON e_tgt.uuid = vk.yksilointitieto::uuid AND e_tgt.equipment_type_id = 17
 WHERE k.valaisinkeskus_id IS NOT NULL
+  AND e_src.is_deleted = false
+  AND e_tgt.is_deleted = false
 ON CONFLICT ON CONSTRAINT uq_equipment_relationship DO NOTHING;
 
 GET DIAGNOSTICS v_migrated = ROW_COUNT;
@@ -117,6 +126,8 @@ JOIN kohteet.equipment e1
 JOIN kohteet.liikennemerkki lm2 ON lm2.id = lll.liikennemerkki_id2
 JOIN kohteet.equipment e2
     ON e2.uuid = lm2.yksilointitieto::uuid AND e2.equipment_type_id = 4
+WHERE e1.is_deleted = false
+  AND e2.is_deleted = false
 ON CONFLICT ON CONSTRAINT uq_equipment_relationship DO NOTHING;
 
 GET DIAGNOSTICS v_migrated = ROW_COUNT;


### PR DESCRIPTION
## Summary

Adds first-class equipment-to-equipment relationships to the InfraRegistry database schema, replacing legacy FK columns and junction tables with a unified relationship model.

## Changes

### 065 — Create equipment relationship schema

- `kohteet.equipment_relationship_type` code list table with `direction` column (`directional` / `bidirectional`) and CHECK constraint
- Seeded 5 relationship types: `belongs_to_center`, `co_located`, `connected_to`, `mounted_on`, `part_of`
- `kohteet.equipment_relationship` junction table with:
  - Foreign keys to `equipment` (ON DELETE CASCADE) and `equipment_relationship_type` (ON DELETE RESTRICT)
  - Unique constraint on (source, target, type) preventing duplicates
  - B-tree indexes on source, target, and composite (source + type)
  - `DEFERRABLE INITIALLY DEFERRED` FKs for flexible insert ordering

### 066 — Migrate legacy relationships

- Migrates `valaisin.valaisinkeskus_id` → equipment_relationship (belongs_to_center)
- Migrates `ryhmasulake.valaisinkeskus_id` → equipment_relationship (belongs_to_center)
- Migrates `kaapeli.valaisinkeskus_id` → equipment_relationship (belongs_to_center)
- Migrates `liikennemerkki_liikennemerkki_linkki` → equipment_relationship (co_located, bidirectional)
- Removes `valaisinkeskusId` from JSONB `properties` of migrated records
- Excludes soft-deleted equipment (`is_deleted = false`) from migration
- Uses `ON CONFLICT DO NOTHING` for idempotent re-runs
- Includes RAISE NOTICE progress diagnostics

## Dependencies

- Depends on scripts 059, 060, 062 (INFRAREGISTRY-292 generic equipment model)

## Testing

- Migration scripts verified against local PostgreSQL with PostGIS
- Idempotency confirmed (safe to re-run)
- Consumed by InfraRegistry API (companion MR in main repository)
